### PR TITLE
Set dummy user if not available

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,11 +35,17 @@ type globalFlags struct {
 }
 
 func (gf globalFlags) WorkingEnvSpec() types.WorkingEnvSpec {
-	return types.WorkingEnvSpec{
+	workingEnvSpec := types.WorkingEnvSpec{
 		SrcDir:          gf.srcDir,
 		GhostWorkingDir: gf.ghostWorkDir,
 		GhostRepo:       gf.ghostRepo,
 	}
+	userName, userEmail, err := git.GetUserConfig(globalOpts.srcDir)
+	if err == nil {
+		workingEnvSpec.GhostUserName = userName
+		workingEnvSpec.GhostUserEmail = userEmail
+	}
+	return workingEnvSpec
 }
 
 var (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,10 +41,11 @@ func (gf globalFlags) WorkingEnvSpec() types.WorkingEnvSpec {
 		GhostRepo:       gf.ghostRepo,
 	}
 	userName, userEmail, err := git.GetUserConfig(globalOpts.srcDir)
-	if err == nil {
-		workingEnvSpec.GhostUserName = userName
-		workingEnvSpec.GhostUserEmail = userEmail
+	if err != nil {
+		log.Debug("failed to get user name and email of the source directory")
 	}
+	workingEnvSpec.GhostUserName = userName
+	workingEnvSpec.GhostUserEmail = userEmail
 	return workingEnvSpec
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,11 +41,12 @@ func (gf globalFlags) WorkingEnvSpec() types.WorkingEnvSpec {
 		GhostRepo:       gf.ghostRepo,
 	}
 	userName, userEmail, err := git.GetUserConfig(globalOpts.srcDir)
-	if err != nil {
+	if err == nil {
+		workingEnvSpec.GhostUserName = userName
+		workingEnvSpec.GhostUserEmail = userEmail
+	} else {
 		log.Debug("failed to get user name and email of the source directory")
 	}
-	workingEnvSpec.GhostUserName = userName
-	workingEnvSpec.GhostUserEmail = userEmail
 	return workingEnvSpec
 }
 

--- a/pkg/ghost/git/repo.go
+++ b/pkg/ghost/git/repo.go
@@ -43,23 +43,37 @@ func InitializeGitDir(dir, repo, branch string) errors.GitGhostError {
 
 // CopyUserConfig copies user config from source directory to destination directory.
 func CopyUserConfig(srcDir, dstDir string) errors.GitGhostError {
+	name, email, err := GetUserConfig(srcDir)
+	if err != nil {
+		return err
+	}
+	return SetUserConfig(dstDir, name, email)
+}
+
+// GetUserConfig returns a user config (name and email) from destination directory.
+func GetUserConfig(dir string) (string, string, errors.GitGhostError) {
 	// Get user config from src
-	userNameBytes, err := util.JustOutputCmd(exec.Command("git", "-C", srcDir, "config", "user.name"))
+	nameBytes, err := util.JustOutputCmd(exec.Command("git", "-C", dir, "config", "user.name"))
 	if err != nil {
-		return errors.WithStack(gherrors.WithMessage(err, "failed to get git user name"))
+		return "", "", errors.WithStack(gherrors.WithMessage(err, "failed to get git user name"))
 	}
-	userName := strings.TrimSuffix(string(userNameBytes), "\n")
-	userEmailBytes, err := util.JustOutputCmd(exec.Command("git", "-C", srcDir, "config", "user.email"))
+	name := strings.TrimSuffix(string(nameBytes), "\n")
+	emailBytes, err := util.JustOutputCmd(exec.Command("git", "-C", dir, "config", "user.email"))
 	if err != nil {
-		return errors.WithStack(gherrors.WithMessage(err, "failed to get git user email"))
+		return "", "", errors.WithStack(gherrors.WithMessage(err, "failed to get git user email"))
 	}
-	userEmail := strings.TrimSuffix(string(userEmailBytes), "\n")
-	// Copy the user config to dst
-	err = util.JustRunCmd(exec.Command("git", "-C", dstDir, "config", "user.name", fmt.Sprintf("\"%s\"", userName)))
+	email := strings.TrimSuffix(string(emailBytes), "\n")
+	return name, email, nil
+}
+
+// SetUserConfig sets a user config (name and email) to destination directory.
+func SetUserConfig(dir, name, email string) errors.GitGhostError {
+	// Set the user config to dst
+	err := util.JustRunCmd(exec.Command("git", "-C", dir, "config", "user.name", fmt.Sprintf("\"%s\"", name)))
 	if err != nil {
 		return errors.WithStack(gherrors.WithMessage(err, "failed to set git user name"))
 	}
-	err = util.JustRunCmd(exec.Command("git", "-C", dstDir, "config", "user.email", fmt.Sprintf("\"%s\"", userEmail)))
+	err = util.JustRunCmd(exec.Command("git", "-C", dir, "config", "user.email", fmt.Sprintf("\"%s\"", email)))
 	if err != nil {
 		return errors.WithStack(gherrors.WithMessage(err, "failed to set git user email"))
 	}

--- a/pkg/ghost/git/repo.go
+++ b/pkg/ghost/git/repo.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/pfnet-research/git-ghost/pkg/util"
 	"github.com/pfnet-research/git-ghost/pkg/util/errors"
+
+	gherrors "github.com/pkg/errors"
 )
 
 var (
@@ -44,20 +46,24 @@ func CopyUserConfig(srcDir, dstDir string) errors.GitGhostError {
 	// Get user config from src
 	userNameBytes, err := util.JustOutputCmd(exec.Command("git", "-C", srcDir, "config", "user.name"))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.WithStack(gherrors.WithMessage(err, "failed to get git user name"))
 	}
 	userName := strings.TrimSuffix(string(userNameBytes), "\n")
 	userEmailBytes, err := util.JustOutputCmd(exec.Command("git", "-C", srcDir, "config", "user.email"))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.WithStack(gherrors.WithMessage(err, "failed to get git user email"))
 	}
 	userEmail := strings.TrimSuffix(string(userEmailBytes), "\n")
 	// Copy the user config to dst
 	err = util.JustRunCmd(exec.Command("git", "-C", dstDir, "config", "user.name", fmt.Sprintf("\"%s\"", userName)))
 	if err != nil {
-		return errors.WithStack(err)
+		return errors.WithStack(gherrors.WithMessage(err, "failed to set git user name"))
 	}
-	return errors.WithStack(util.JustRunCmd(exec.Command("git", "-C", dstDir, "config", "user.email", fmt.Sprintf("\"%s\"", userEmail))))
+	err = util.JustRunCmd(exec.Command("git", "-C", dstDir, "config", "user.email", fmt.Sprintf("\"%s\"", userEmail)))
+	if err != nil {
+		return errors.WithStack(gherrors.WithMessage(err, "failed to set git user email"))
+	}
+	return nil
 }
 
 // CommitAndPush commits and push to its origin

--- a/pkg/ghost/types/workingenv.go
+++ b/pkg/ghost/types/workingenv.go
@@ -24,6 +24,11 @@ import (
 	log "github.com/Sirupsen/logrus"
 )
 
+const (
+	defaultGhostUserName  = "Git Ghost"
+	defaultGhostUserEmail = "git-ghost@example.com"
+)
+
 // WorkingEnvSpec abstract an environment git-ghost works with
 type WorkingEnvSpec struct {
 	// SrcDir is local git directory
@@ -32,6 +37,10 @@ type WorkingEnvSpec struct {
 	GhostWorkingDir string
 	// GhostRepo is a repository url git-ghost works with
 	GhostRepo string
+	// GhostUserName is a user name which is used in ghost working directories.
+	GhostUserName string
+	// GhostUserEmail is a user email which is used in ghost working directories.
+	GhostUserEmail string
 }
 
 // WorkingEnv is initialized environment containing temporary local ghost repository
@@ -49,7 +58,15 @@ func (weSpec WorkingEnvSpec) Initialize() (*WorkingEnv, errors.GitGhostError) {
 	if ggerr != nil {
 		return nil, ggerr
 	}
-	ggerr = git.CopyUserConfig(weSpec.SrcDir, ghostDir)
+	ghostUserName := defaultGhostUserName
+	if weSpec.GhostUserName != "" {
+		ghostUserName = weSpec.GhostUserName
+	}
+	ghostUserEmail := defaultGhostUserEmail
+	if weSpec.GhostUserEmail != "" {
+		ghostUserEmail = weSpec.GhostUserEmail
+	}
+	ggerr = git.SetUserConfig(ghostDir, ghostUserName, ghostUserEmail)
 	if ggerr != nil {
 		return nil, ggerr
 	}


### PR DESCRIPTION
The current implementation of git ghost copies git user config to ghost working directory to use git, but in some situation, git user config is not set especially in a remote environment because git clone doesn't need git user config. I think a user wants to execute `git ghost pull` just after `git clone`, so git ghost should help it by using dummy user config so a user can pull their changes without setting git user config.
Now, git ghost copies actual user git config if available, but uses dummy user config if not.