### PR TITLE
Default push from hash

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -58,14 +58,11 @@ __git-ghost_custom_func() {
 	`
 )
 
-func init() {
-	RootCmd.AddCommand(completionCmd)
-}
-
-var completionCmd = &cobra.Command{
-	Use:   "completion SHELL",
-	Short: "output shell completion code for the specified shell (bash or zsh)",
-	Long: `Write bash or zsh shell completion code to standard output.
+func NewCompletionCmd(cmd *cobra.Command) *cobra.Command {
+	return &cobra.Command{
+		Use:   "completion SHELL",
+		Short: "output shell completion code for the specified shell (bash or zsh)",
+		Long: `Write bash or zsh shell completion code to standard output.
 
 	For bash, ensure you have bash completions installed and enabled.
 	To access completions in your current shell, run
@@ -75,21 +72,22 @@ var completionCmd = &cobra.Command{
 	For zsh, output to a file in a directory referenced by the $fpath shell
 	variable.
 `,
-	Args: cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		shell := args[0]
-		RootCmd.BashCompletionFunction = bashCompletionFunc
-		availableCompletions := map[string]func(io.Writer) error{
-			"bash": RootCmd.GenBashCompletion,
-			"zsh":  RootCmd.GenZshCompletion,
-		}
-		completion, ok := availableCompletions[shell]
-		if !ok {
-			fmt.Printf("Invalid shell '%s'. The supported shells are bash and zsh.\n", shell)
-			os.Exit(1)
-		}
-		if err := completion(os.Stdout); err != nil {
-			log.Fatal(err)
-		}
-	},
+		Args: cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			shell := args[0]
+			cmd.BashCompletionFunction = bashCompletionFunc
+			availableCompletions := map[string]func(io.Writer) error{
+				"bash": cmd.GenBashCompletion,
+				"zsh":  cmd.GenZshCompletion,
+			}
+			completion, ok := availableCompletions[shell]
+			if !ok {
+				fmt.Printf("Invalid shell '%s'. The supported shells are bash and zsh.\n", shell)
+				os.Exit(1)
+			}
+			if err := completion(os.Stdout); err != nil {
+				log.Fatal(err)
+			}
+		},
+	}
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -58,7 +58,7 @@ __git-ghost_custom_func() {
 	`
 )
 
-func NewCompletionCmd(cmd *cobra.Command) *cobra.Command {
+func NewCompletionCmd(rootCmd *cobra.Command) *cobra.Command {
 	return &cobra.Command{
 		Use:   "completion SHELL",
 		Short: "output shell completion code for the specified shell (bash or zsh)",
@@ -75,10 +75,10 @@ func NewCompletionCmd(cmd *cobra.Command) *cobra.Command {
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			shell := args[0]
-			cmd.BashCompletionFunction = bashCompletionFunc
+			rootCmd.BashCompletionFunction = bashCompletionFunc
 			availableCompletions := map[string]func(io.Writer) error{
-				"bash": cmd.GenBashCompletion,
-				"zsh":  cmd.GenZshCompletion,
+				"bash": rootCmd.GenBashCompletion,
+				"zsh":  rootCmd.GenZshCompletion,
 			}
 			completion, ok := availableCompletions[shell]
 			if !ok {

--- a/cmd/delete.go
+++ b/cmd/delete.go
@@ -25,10 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(NewDeleteCommand())
-}
-
 type deleteFlags struct {
 	hashFrom string
 	hashTo   string

--- a/cmd/gc.go
+++ b/cmd/gc.go
@@ -20,10 +20,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(gcCmd)
-}
-
 var gcCmd = &cobra.Command{
 	Use:   "gc",
 	Short: "gc ghost commits from remote repository.",

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -27,10 +27,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(NewListCommand())
-}
-
 var outputTypes = []string{"only-from", "only-to"}
 var regexpOutputPattern = regexp.MustCompile("^(|" + strings.Join(outputTypes, "|") + ")$")
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -25,10 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(NewPullCommand())
-}
-
 type pullFlags struct {
 	// forceApply bool
 }

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -35,28 +35,28 @@ func NewPushCommand() *cobra.Command {
 		flags pushFlags
 	)
 	command := &cobra.Command{
-		Use:   fmt.Sprintf("push [from-hash(default=%s)]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("push [from-hash(default=%s)]", ghostDefaultPushFromHash),
 		Short: "push commits(hash1...hash2), diff(hash...current state) to your ghost repo",
 		Long:  "push commits or diff or all to your ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'push diff' command.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	}
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash(default=HEAD)]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash(default=HEAD)]", ghostDefaultPushFromHash),
 		Short: "push commits between two commits to your ghost repo",
 		Long:  "push all the commits between [from-hash]...[to-hash] to your ghost repo.",
 		Args:  cobra.RangeArgs(0, 2),
 		Run:   runPushCommitsCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("diff [from-hash(default=%s)]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("diff [from-hash(default=%s)]", ghostDefaultPushFromHash),
 		Short: "push diff from a commit to current state of your working dir to your ghost repo",
 		Long:  "push diff from [from-hash] to current state of your working dir to your ghost repo.  please be noted that this pushes only diff, which means that it doesn't save any commits information.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("all [commits-from-hash(default=%s)] [diff-from-hash(default=HEAD)]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("all [commits-from-hash(default=%s)] [diff-from-hash(default=HEAD)]", ghostDefaultPushFromHash),
 		Short: "push both commits and diff to your ghost repo",
 		Long:  "push both commits([commits-from-hash]...[diff-from-hash]) and diff([diff-from-hash]...current state) to your ghost repo",
 		Args:  cobra.RangeArgs(0, 2),
@@ -76,7 +76,7 @@ type pushCommitsArg struct {
 
 func newPushCommitsArg(args []string) pushCommitsArg {
 	pushCommitsArg := pushCommitsArg{
-		commitsFrom: globalOpts.ghostDefaultPushFromHash,
+		commitsFrom: ghostDefaultPushFromHash,
 		commitsTo:   "HEAD",
 	}
 	if len(args) >= 1 {
@@ -162,7 +162,7 @@ func (arg pushDiffArg) validate() errors.GitGhostError {
 
 func runPushDiffCommand(flags *pushFlags) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		pushArg := newPushDiffArg(globalOpts.ghostDefaultPushFromHash, args)
+		pushArg := newPushDiffArg(ghostDefaultPushFromHash, args)
 		if err := pushArg.validate(); err != nil {
 			errors.LogErrorWithStack(err)
 			os.Exit(1)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -35,30 +35,30 @@ func NewPushCommand() *cobra.Command {
 		flags pushFlags
 	)
 	command := &cobra.Command{
-		Use:   fmt.Sprintf("push [from-hash(default=%s)]", ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("push [diff-from-hash(default=%s)]", ghostDefaultPushFromHash),
 		Short: "push commits(hash1...hash2), diff(hash...current state) to your ghost repo",
-		Long:  "push commits or diff or all to your ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'push diff' command.",
+		Long:  "push commits or diff or all to your ghost repo. If you didn't specify any subcommand, this commands works as an alias for 'push diff' command. The default diff-from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH env.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	}
 	command.AddCommand(&cobra.Command{
 		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash(default=HEAD)]", ghostDefaultPushFromHash),
 		Short: "push commits between two commits to your ghost repo",
-		Long:  "push all the commits between [from-hash]...[to-hash] to your ghost repo.",
+		Long:  "push all the commits between [from-hash]...[to-hash] to your ghost repo. The default from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH env.",
 		Args:  cobra.RangeArgs(0, 2),
 		Run:   runPushCommitsCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("diff [from-hash(default=%s)]", ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("diff [diff-from-hash(default=%s)]", ghostDefaultPushFromHash),
 		Short: "push diff from a commit to current state of your working dir to your ghost repo",
-		Long:  "push diff from [from-hash] to current state of your working dir to your ghost repo.  please be noted that this pushes only diff, which means that it doesn't save any commits information.",
+		Long:  "push diff from [from-hash] to current state of your working dir to your ghost repo. please be noted that this pushes only diff, which means that it doesn't save any commits information. The default diff-from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH env.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
 		Use:   fmt.Sprintf("all [commits-from-hash(default=%s)] [diff-from-hash(default=HEAD)]", ghostDefaultPushFromHash),
 		Short: "push both commits and diff to your ghost repo",
-		Long:  "push both commits([commits-from-hash]...[diff-from-hash]) and diff([diff-from-hash]...current state) to your ghost repo",
+		Long:  "push both commits([commits-from-hash]...[diff-from-hash]) and diff([diff-from-hash]...current state) to your ghost repo. The default commits-from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH env.",
 		Args:  cobra.RangeArgs(0, 2),
 		Run:   runPushAllCommand(&flags),
 	})

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -30,40 +30,36 @@ type pushFlags struct {
 	followSymlinks    bool
 }
 
-func init() {
-	RootCmd.AddCommand(NewPushCommand())
-}
-
 func NewPushCommand() *cobra.Command {
 	var (
 		flags pushFlags
 	)
 	command := &cobra.Command{
-		Use:   "push [from-hash(default=HEAD)]",
+		Use:   fmt.Sprintf("push [from-hash(default=%s)]", globalOpts.ghostDefaultPushFromHash),
 		Short: "push commits(hash1...hash2), diff(hash...current state) to your ghost repo",
 		Long:  "push commits or diff or all to your ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'push diff' command.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	}
 	command.AddCommand(&cobra.Command{
-		Use:   "commits [from-hash] [to-hash(default=HEAD)]",
+		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash(default=HEAD)]", globalOpts.ghostDefaultPushFromHash),
 		Short: "push commits between two commits to your ghost repo",
 		Long:  "push all the commits between [from-hash]...[to-hash] to your ghost repo.",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.RangeArgs(0, 2),
 		Run:   runPushCommitsCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   "diff [from-hash(default=HEAD)]",
+		Use:   fmt.Sprintf("diff [from-hash(default=%s)]", globalOpts.ghostDefaultPushFromHash),
 		Short: "push diff from a commit to current state of your working dir to your ghost repo",
 		Long:  "push diff from [from-hash] to current state of your working dir to your ghost repo.  please be noted that this pushes only diff, which means that it doesn't save any commits information.",
 		Args:  cobra.RangeArgs(0, 1),
 		Run:   runPushDiffCommand(&flags),
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   "all [commits-from-hash] [diff-from-hash(default=HEAD)]",
+		Use:   fmt.Sprintf("all [commits-from-hash(default=%s)] [diff-from-hash(default=HEAD)]", globalOpts.ghostDefaultPushFromHash),
 		Short: "push both commits and diff to your ghost repo",
 		Long:  "push both commits([commits-from-hash]...[diff-from-hash]) and diff([diff-from-hash]...current state) to your ghost repo",
-		Args:  cobra.RangeArgs(1, 2),
+		Args:  cobra.RangeArgs(0, 2),
 		Run:   runPushAllCommand(&flags),
 	})
 
@@ -80,7 +76,7 @@ type pushCommitsArg struct {
 
 func newPushCommitsArg(args []string) pushCommitsArg {
 	pushCommitsArg := pushCommitsArg{
-		commitsFrom: "",
+		commitsFrom: globalOpts.ghostDefaultPushFromHash,
 		commitsTo:   "HEAD",
 	}
 	if len(args) >= 1 {
@@ -146,7 +142,7 @@ type pushDiffArg struct {
 
 func newPushDiffArg(args []string) pushDiffArg {
 	pushDiffArg := pushDiffArg{
-		diffFrom: "HEAD",
+		diffFrom: globalOpts.ghostDefaultPushFromHash,
 	}
 	if len(args) >= 1 {
 		pushDiffArg.diffFrom = args[0]
@@ -200,13 +196,18 @@ func runPushDiffCommand(flags *pushFlags) func(cmd *cobra.Command, args []string
 
 func runPushAllCommand(flags *pushFlags) func(cmd *cobra.Command, args []string) {
 	return func(cmd *cobra.Command, args []string) {
-		pushCommitsArg := newPushCommitsArg(args[0:1])
+		pushCommitsArg := newPushCommitsArg(args)
 		if err := pushCommitsArg.validate(); err != nil {
 			errors.LogErrorWithStack(err)
 			os.Exit(1)
 		}
 
-		pushDiffArg := newPushDiffArg(args[1:])
+		if len(args) > 0 {
+			args = args[1:]
+		} else {
+			args = []string{}
+		}
+		pushDiffArg := newPushDiffArg(args)
 		if err := pushDiffArg.validate(); err != nil {
 			errors.LogErrorWithStack(err)
 			os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,11 +27,12 @@ import (
 )
 
 type globalFlags struct {
-	srcDir       string
-	ghostWorkDir string
-	ghostPrefix  string
-	ghostRepo    string
-	verbose      int
+	srcDir                   string
+	ghostWorkDir             string
+	ghostPrefix              string
+	ghostRepo                string
+	ghostDefaultPushFromHash string
+	verbose                  int
 }
 
 func (gf globalFlags) WorkingEnvSpec() types.WorkingEnvSpec {
@@ -142,6 +143,11 @@ func (flags *globalFlags) SetDefaults() errors.GitGhostError {
 	if globalOpts.ghostRepo == "" {
 		globalOpts.ghostRepo = os.Getenv("GIT_GHOST_REPO")
 	}
+	fromHash := os.Getenv("GIT_GHOST_DEFAULT_PUSH_FROM_HASH")
+	if fromHash == "" {
+		fromHash = "HEAD"
+	}
+	globalOpts.ghostDefaultPushFromHash = fromHash
 	return nil
 }
 
@@ -158,6 +164,9 @@ func (flags *globalFlags) Validate() errors.GitGhostError {
 	}
 	if flags.ghostRepo == "" {
 		return errors.New("ghost-repo must be specified")
+	}
+	if flags.ghostDefaultPushFromHash == "" {
+		return errors.New("ghost-default-from-hash must be specified")
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -27,11 +27,11 @@ import (
 )
 
 type globalFlags struct {
-	srcDir                   string
-	ghostWorkDir             string
-	ghostPrefix              string
-	ghostRepo                string
-	verbose                  int
+	srcDir       string
+	ghostWorkDir string
+	ghostPrefix  string
+	ghostRepo    string
+	verbose      int
 }
 
 func (gf globalFlags) WorkingEnvSpec() types.WorkingEnvSpec {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -55,50 +55,57 @@ var (
 	Revision string
 )
 
-var RootCmd = &cobra.Command{
-	Use:           "git-ghost",
-	Short:         "git-ghost",
-	SilenceErrors: false,
-	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		if cmd.Use == "version" {
-			return nil
-		}
-		err := validateEnvironment()
-		if err != nil {
-			return err
-		}
-		err = globalOpts.SetDefaults()
-		if err != nil {
-			return err
-		}
-		err = globalOpts.Validate()
-		if err != nil {
-			return err
-		}
-		switch globalOpts.verbose {
-		case 0:
-			log.SetLevel(log.ErrorLevel)
-		case 1:
-			log.SetLevel(log.InfoLevel)
-		case 2:
-			log.SetLevel(log.DebugLevel)
-		case 3:
-			log.SetLevel(log.TraceLevel)
-		}
-		return nil
-	},
-}
-
 var globalOpts globalFlags
 
-func init() {
+func NewRootCmd() *cobra.Command {
 	cobra.OnInitialize()
-	RootCmd.PersistentFlags().StringVar(&globalOpts.srcDir, "src-dir", "", "source directory which you create ghost from (default to PWD env)")
-	RootCmd.PersistentFlags().StringVar(&globalOpts.ghostWorkDir, "ghost-working-dir", "", "local root directory for git-ghost interacting with ghost repository (default to a temporary directory)")
-	RootCmd.PersistentFlags().StringVar(&globalOpts.ghostPrefix, "ghost-prefix", "", "prefix of ghost branch name (default to GIT_GHOST_PREFIX env, or ghost)")
-	RootCmd.PersistentFlags().StringVar(&globalOpts.ghostRepo, "ghost-repo", "", "git remote url for ghosts repository (default to GIT_GHOST_REPO env)")
-	RootCmd.PersistentFlags().CountVarP(&globalOpts.verbose, "verbose", "v", "verbose mode")
-	RootCmd.AddCommand(versionCmd)
+	rootCmd := &cobra.Command{
+		Use:           "git-ghost",
+		Short:         "git-ghost",
+		SilenceErrors: false,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if cmd.Use == "version" {
+				return nil
+			}
+			err := validateEnvironment()
+			if err != nil {
+				return err
+			}
+			err = globalOpts.SetDefaults()
+			if err != nil {
+				return err
+			}
+			err = globalOpts.Validate()
+			if err != nil {
+				return err
+			}
+			switch globalOpts.verbose {
+			case 0:
+				log.SetLevel(log.ErrorLevel)
+			case 1:
+				log.SetLevel(log.InfoLevel)
+			case 2:
+				log.SetLevel(log.DebugLevel)
+			case 3:
+				log.SetLevel(log.TraceLevel)
+			}
+			return nil
+		},
+	}
+	rootCmd.PersistentFlags().StringVar(&globalOpts.srcDir, "src-dir", "", "source directory which you create ghost from (default to PWD env)")
+	rootCmd.PersistentFlags().StringVar(&globalOpts.ghostWorkDir, "ghost-working-dir", "", "local root directory for git-ghost interacting with ghost repository (default to a temporary directory)")
+	rootCmd.PersistentFlags().StringVar(&globalOpts.ghostPrefix, "ghost-prefix", "", "prefix of ghost branch name (default to GIT_GHOST_PREFIX env, or ghost)")
+	rootCmd.PersistentFlags().StringVar(&globalOpts.ghostRepo, "ghost-repo", "", "git remote url for ghosts repository (default to GIT_GHOST_REPO env)")
+	rootCmd.PersistentFlags().CountVarP(&globalOpts.verbose, "verbose", "v", "verbose mode")
+	rootCmd.AddCommand(NewPushCommand())
+	rootCmd.AddCommand(NewPullCommand())
+	rootCmd.AddCommand(NewShowCommand())
+	rootCmd.AddCommand(NewListCommand())
+	rootCmd.AddCommand(NewDeleteCommand())
+	rootCmd.AddCommand(gcCmd)
+	rootCmd.AddCommand(versionCmd)
+	rootCmd.AddCommand(NewCompletionCmd(rootCmd))
+	return rootCmd
 }
 
 var versionCmd = &cobra.Command{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,6 @@ type globalFlags struct {
 	ghostWorkDir             string
 	ghostPrefix              string
 	ghostRepo                string
-	ghostDefaultPushFromHash string
 	verbose                  int
 }
 
@@ -56,9 +55,14 @@ var (
 	Revision string
 )
 
+var (
+	ghostDefaultPushFromHash string = "HEAD"
+)
+
 var globalOpts globalFlags
 
 func NewRootCmd() *cobra.Command {
+	setDefaultGlobalVars()
 	cobra.OnInitialize()
 	rootCmd := &cobra.Command{
 		Use:           "git-ghost",
@@ -143,11 +147,6 @@ func (flags *globalFlags) SetDefaults() errors.GitGhostError {
 	if globalOpts.ghostRepo == "" {
 		globalOpts.ghostRepo = os.Getenv("GIT_GHOST_REPO")
 	}
-	fromHash := os.Getenv("GIT_GHOST_DEFAULT_PUSH_FROM_HASH")
-	if fromHash == "" {
-		fromHash = "HEAD"
-	}
-	globalOpts.ghostDefaultPushFromHash = fromHash
 	return nil
 }
 
@@ -165,8 +164,12 @@ func (flags *globalFlags) Validate() errors.GitGhostError {
 	if flags.ghostRepo == "" {
 		return errors.New("ghost-repo must be specified")
 	}
-	if flags.ghostDefaultPushFromHash == "" {
-		return errors.New("ghost-default-from-hash must be specified")
-	}
 	return nil
+}
+
+func setDefaultGlobalVars() {
+	fromHash := os.Getenv("GIT_GHOST_DEFAULT_PUSH_FROM_HASH")
+	if fromHash != "" {
+		ghostDefaultPushFromHash = fromHash
+	}
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -25,10 +25,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	RootCmd.AddCommand(NewShowCommand())
-}
-
 func NewShowCommand() *cobra.Command {
 	command := &cobra.Command{
 		Use:   "show [from-hash(default=HEAD)] [diff-hash]",

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,30 +28,30 @@ import (
 
 func NewShowCommand() *cobra.Command {
 	command := &cobra.Command{
-		Use:   fmt.Sprintf("show [from-hash(default=%s)] [diff-hash]", ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("show [diff-from-hash(default=%s)] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show commits(hash1...hash2), diff(hash...current state) in ghost repo",
-		Long:  "show commits or diff or all from ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'show diff' command.",
+		Long:  "show commits or diff or all from ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'show diff' command. The default diff-from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH.",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	}
 	command.AddCommand(&cobra.Command{
 		Use:   fmt.Sprintf("diff [diff-from-hash(default=%s)] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show diff in ghost repo ",
-		Long:  "show diff from [diff-from-hash] to [diff-hash] in ghost repo",
+		Long:  "show diff from [diff-from-hash] to [diff-hash] in ghost repo. The default diff-from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH.",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	})
 	command.AddCommand(&cobra.Command{
 		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash]", ghostDefaultPushFromHash),
 		Short: "show commits in ghost repo",
-		Long:  "show commits from [from-hash] to [to-hash] in ghost repo",
+		Long:  "show commits from [from-hash] to [to-hash] in ghost repo. The default from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH.",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowCommitsCommand,
 	})
 	command.AddCommand(&cobra.Command{
 		Use:   fmt.Sprintf("all [from-hash(default=%s)] [to-hash] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show both commits and diff in ghost repo",
-		Long:  "show commits([from-hash]...[to-hash]) and diff([to-hash]...[diff-hash]) in ghost repo",
+		Long:  "show commits([from-hash]...[to-hash]) and diff([to-hash]...[diff-hash]) in ghost repo. The default from-hash can be changed by GIT_GHOST_DEFAULT_PUSH_FROM_HASH.",
 		Args:  cobra.RangeArgs(2, 3),
 		Run:   runShowAllCommand,
 	})

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/pfnet-research/git-ghost/pkg/ghost"
@@ -27,28 +28,28 @@ import (
 
 func NewShowCommand() *cobra.Command {
 	command := &cobra.Command{
-		Use:   "show [from-hash(default=HEAD)] [diff-hash]",
+		Use:   fmt.Sprintf("show [from-hash(default=%s)] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
 		Short: "show commits(hash1...hash2), diff(hash...current state) in ghost repo",
 		Long:  "show commits or diff or all from ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'show diff' command.",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	}
 	command.AddCommand(&cobra.Command{
-		Use:   "diff [diff-from-hash(default=HEAD)] [diff-hash]",
+		Use:   fmt.Sprintf("diff [diff-from-hash(default=%s)] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
 		Short: "show diff in ghost repo ",
 		Long:  "show diff from [diff-from-hash] to [diff-hash] in ghost repo",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   "commits [from-hash(default=HEAD)] [to-hash]",
+		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash]", globalOpts.ghostDefaultPushFromHash),
 		Short: "show commits in ghost repo",
 		Long:  "show commits from [from-hash] to [to-hash] in ghost repo",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowCommitsCommand,
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   "all [from-hash(default=HEAD)] [to-hash] [diff-hash]",
+		Use:   fmt.Sprintf("all [from-hash(default=%s)] [to-hash] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
 		Short: "show both commits and diff in ghost repo",
 		Long:  "show commits([from-hash]...[to-hash]) and diff([to-hash]...[diff-hash]) in ghost repo",
 		Args:  cobra.RangeArgs(2, 3),
@@ -64,7 +65,7 @@ type showCommitsArg struct {
 
 func newShowCommitsArg(args []string) showCommitsArg {
 	arg := showCommitsArg{
-		commitsFrom: "HEAD",
+		commitsFrom: globalOpts.ghostDefaultPushFromHash,
 		commitsTo:   "",
 	}
 
@@ -123,7 +124,7 @@ type showDiffArg struct {
 
 func newShowDiffArg(args []string) showDiffArg {
 	arg := showDiffArg{
-		diffFrom: "HEAD",
+		diffFrom: globalOpts.ghostDefaultPushFromHash,
 		diffHash: "",
 	}
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -28,28 +28,28 @@ import (
 
 func NewShowCommand() *cobra.Command {
 	command := &cobra.Command{
-		Use:   fmt.Sprintf("show [from-hash(default=%s)] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("show [from-hash(default=%s)] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show commits(hash1...hash2), diff(hash...current state) in ghost repo",
 		Long:  "show commits or diff or all from ghost repo.  If you didn't specify any subcommand, this commands works as an alias for 'show diff' command.",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	}
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("diff [diff-from-hash(default=%s)] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("diff [diff-from-hash(default=%s)] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show diff in ghost repo ",
 		Long:  "show diff from [diff-from-hash] to [diff-hash] in ghost repo",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowDiffCommand,
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("commits [from-hash(default=%s)] [to-hash]", ghostDefaultPushFromHash),
 		Short: "show commits in ghost repo",
 		Long:  "show commits from [from-hash] to [to-hash] in ghost repo",
 		Args:  cobra.RangeArgs(1, 2),
 		Run:   runShowCommitsCommand,
 	})
 	command.AddCommand(&cobra.Command{
-		Use:   fmt.Sprintf("all [from-hash(default=%s)] [to-hash] [diff-hash]", globalOpts.ghostDefaultPushFromHash),
+		Use:   fmt.Sprintf("all [from-hash(default=%s)] [to-hash] [diff-hash]", ghostDefaultPushFromHash),
 		Short: "show both commits and diff in ghost repo",
 		Long:  "show commits([from-hash]...[to-hash]) and diff([to-hash]...[diff-hash]) in ghost repo",
 		Args:  cobra.RangeArgs(2, 3),
@@ -65,7 +65,7 @@ type showCommitsArg struct {
 
 func newShowCommitsArg(args []string) showCommitsArg {
 	arg := showCommitsArg{
-		commitsFrom: globalOpts.ghostDefaultPushFromHash,
+		commitsFrom: ghostDefaultPushFromHash,
 		commitsTo:   "",
 	}
 
@@ -153,7 +153,7 @@ func (arg showDiffArg) validate() errors.GitGhostError {
 }
 
 func runShowDiffCommand(cmd *cobra.Command, args []string) {
-	arg := newShowDiffArg(globalOpts.ghostDefaultPushFromHash, args)
+	arg := newShowDiffArg(ghostDefaultPushFromHash, args)
 	if err := arg.validate(); err != nil {
 		errors.LogErrorWithStack(err)
 		os.Exit(1)

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -122,9 +122,9 @@ type showDiffArg struct {
 	diffHash string
 }
 
-func newShowDiffArg(args []string) showDiffArg {
+func newShowDiffArg(defaultFromHash string, args []string) showDiffArg {
 	arg := showDiffArg{
-		diffFrom: globalOpts.ghostDefaultPushFromHash,
+		diffFrom: defaultFromHash,
 		diffHash: "",
 	}
 
@@ -153,7 +153,7 @@ func (arg showDiffArg) validate() errors.GitGhostError {
 }
 
 func runShowDiffCommand(cmd *cobra.Command, args []string) {
-	arg := newShowDiffArg(args)
+	arg := newShowDiffArg(globalOpts.ghostDefaultPushFromHash, args)
 	if err := arg.validate(); err != nil {
 		errors.LogErrorWithStack(err)
 		os.Exit(1)
@@ -183,10 +183,10 @@ func runShowAllCommand(cmd *cobra.Command, args []string) {
 	switch len(args) {
 	case 3:
 		showCommitsArg = newShowCommitsArg(args[0:2])
-		showDiffArg = newShowDiffArg(args[1:])
+		showDiffArg = newShowDiffArg("HEAD", args[1:])
 	case 2:
 		showCommitsArg = newShowCommitsArg(args[0:1])
-		showDiffArg = newShowDiffArg(args)
+		showDiffArg = newShowDiffArg("HEAD", args)
 	default:
 		log.Error(cmd.Args(cmd, args))
 		os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -28,7 +28,8 @@ func init() {
 
 func main() {
 	// RootCmd prints errors if exists
-	if err := cmd.RootCmd.Execute(); err != nil {
+	rootCmd := cmd.NewRootCmd()
+	if err := rootCmd.Execute(); err != nil {
 		os.Exit(-1)
 	}
 }


### PR DESCRIPTION
I implemented `GIT_GHOST_DEFAULT_PUSH_FROM_HASH` which is used for only `push` and `show` but not for `pull` because `HEAD` is expected in the situation of using `pull`.
@omura Do you think we should generalize it as `GIT_GHOST_DEFAULT_FROM_HASH` and use this value in `pull` as well?

Fixes #16 