### PR TITLE
Execute goveralls after success in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,5 +17,8 @@ install:
 before_script: make lint
 
 script:
-- make test coverage && goveralls -coverprofile=profile.cov -service=travis-ci
+- make test coverage
 - make install e2e
+
+after_success:
+- goveralls -coverprofile=profile.cov -service=travis-ci


### PR DESCRIPTION
The CI fails to execute goveralls in forked repos if the forking user doesn't set up travis. As failures can be ignoed in `after_success`, we should move it there.