### PR TITLE
Fix validation message

### DIFF
--- a/pkg/ghost/git/file.go
+++ b/pkg/ghost/git/file.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"syscall"
 
 	"github.com/pfnet-research/git-ghost/pkg/util"
 	"github.com/pfnet-research/git-ghost/pkg/util/errors"
@@ -94,13 +93,9 @@ func AppendNonIndexedDiffFiles(dir, filepath string, nonIndexedFilepaths []strin
 		cmd.Stdout = f
 		ggerr := util.JustRunCmd(cmd)
 		if ggerr != nil {
-			if exiterr, ok := ggerr.Cause().(*exec.ExitError); ok {
-				if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
-					// exit 1 is valid for git diff
-					if status.ExitStatus() == 1 {
-						continue
-					}
-				}
+			if util.GetExitCode(ggerr.Cause()) == 1 {
+				// exit 1 is valid for git diff
+				continue
 			}
 			errs = multierror.Append(errs, ggerr)
 		}

--- a/pkg/ghost/git/validation.go
+++ b/pkg/ghost/git/validation.go
@@ -30,7 +30,12 @@ func ValidateGit() errors.GitGhostError {
 
 // ValidateCommittish check committish is valid on dir
 func ValidateCommittish(dir, committish string) errors.GitGhostError {
-	return util.JustRunCmd(
+	output, err := util.JustOutputCmd(
 		exec.Command("git", "-C", dir, "cat-file", "-e", committish),
 	)
+	if err != nil && util.GetExitCode(err.Cause()) == 1 && len(output) == 0 {
+		// exit 1 is for unexisting committish.
+		return errors.Errorf("%s does not exist", committish)
+	}
+	return err
 }

--- a/pkg/util/exec.go
+++ b/pkg/util/exec.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"syscall"
 
 	"github.com/pfnet-research/git-ghost/pkg/util/errors"
 
@@ -61,4 +62,13 @@ func JustRunCmd(cmd *exec.Cmd) errors.GitGhostError {
 		return errors.WithStack(err)
 	}
 	return nil
+}
+
+func GetExitCode(err error) int {
+	if exiterr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			return status.ExitStatus()
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
When unexisting commit hash is specified, Git Ghost outputs the following error.

```
$ git ghost show aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa a
ERRO[0003] exit status 1
```

This is too hard for users to know if the given commit does not exist.