### PR TITLE
Fix segmentation violation on no commit diff pull

### DIFF
--- a/pkg/ghost/pull.go
+++ b/pkg/ghost/pull.go
@@ -32,7 +32,7 @@ type PullOptions struct {
 func pullAndApply(spec types.PullableGhostBranchSpec, we types.WorkingEnv) errors.GitGhostError {
 	pulledBranch, err := spec.PullBranch(we)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 	return pulledBranch.Apply(we)
 }

--- a/pkg/ghost/show.go
+++ b/pkg/ghost/show.go
@@ -44,11 +44,7 @@ func pullAndshow(branchSpec types.PullableGhostBranchSpec, we types.WorkingEnv, 
 	if err != nil {
 		return err
 	}
-	if branch != nil {
-		err := branch.Show(we, writer)
-		return err
-	}
-	return nil
+	return branch.Show(we, writer)
 }
 
 // Show writes ghost branches contents to option.Writer

--- a/pkg/ghost/types/branch.go
+++ b/pkg/ghost/types/branch.go
@@ -195,7 +195,6 @@ func apply(ghost GhostBranch, we WorkingEnv, expectedSrcHead string) errors.GitG
 		return git.ApplyDiffBundleFile(we.SrcDir, path.Join(we.GhostDir, ghost.FileName()))
 	case DiffBranch:
 		return git.ApplyDiffPatchFile(we.SrcDir, path.Join(we.GhostDir, ghost.FileName()))
-
 	default:
 		return errors.Errorf("not supported on type = %+v", reflect.TypeOf(ghost))
 	}
@@ -208,6 +207,13 @@ func (bs CommitsBranch) Show(we WorkingEnv, writer io.Writer) errors.GitGhostErr
 
 // Apply applies contents(diff or patch) of this ghost branch on passed working env
 func (bs CommitsBranch) Apply(we WorkingEnv) errors.GitGhostError {
+	if bs.CommitHashFrom == bs.CommitHashTo {
+		log.WithFields(log.Fields{
+			"from": bs.CommitHashFrom,
+			"to":   bs.CommitHashTo,
+		}).Warn("skipping apply ghost commits branch because from-hash and to-hash is the same.")
+		return nil
+	}
 	err := apply(bs, we, bs.CommitHashFrom)
 	if err != nil {
 		return err

--- a/pkg/ghost/types/branchspec.go
+++ b/pkg/ghost/types/branchspec.go
@@ -108,14 +108,6 @@ func (bs CommitsBranchSpec) PullBranch(we WorkingEnv) (GhostBranch, errors.GitGh
 		CommitHashFrom: resolved.CommittishFrom,
 		CommitHashTo:   resolved.CommittishTo,
 	}
-	if branch.CommitHashFrom == branch.CommitHashTo {
-		log.WithFields(log.Fields{
-			"from": branch.CommitHashFrom,
-			"to":   branch.CommitHashTo,
-		}).Warn("skipping pull and apply ghost commits branch because from-hash and to-hash is the same.")
-		return nil, nil
-	}
-
 	err = pull(branch, we)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Pulling empty commit diff causes seg fault.
You can reproduce this by `git ghost pull commits HEAD HEAD` and get an error like below.

```
$ git ghost pull commits HEAD HEAD
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1191ee1]

goroutine 1 [running]:
github.com/pfnet-research/git-ghost/pkg/ghost.pullAndApply(0x12511e0, 0xc0000a3110, 0xc000014194, 0x3f, 0xc000024207, 0x31, 0xc00002410f, 0x27, 0xc0000e6680, 0x10, ...)
        /Users/dtaniwaki/github/src/github.com/pfnet-research/git-ghost/pkg/ghost/pull.go:37 +0xe1
github.com/pfnet-research/git-ghost/pkg/ghost.Pull(0xc000014194, 0x3f, 0xc000024207, 0x31, 0xc00002410f, 0x27, 0xc0000e6680, 0x10, 0xc0000185c0, 0x19, ...)
        /Users/dtaniwaki/github/src/github.com/pfnet-research/git-ghost/pkg/ghost/pull.go:50 +0x438
github.com/pfnet-research/git-ghost/cmd.runPullCommitsCommand.func1(0xc0000ee280, 0xc0000aa500, 0x2, 0x2)
        /Users/dtaniwaki/github/src/github.com/pfnet-research/git-ghost/cmd/pull.go:126 +0x1f4
github.com/spf13/cobra.(*Command).execute(0xc0000ee280, 0xc0000aa480, 0x2, 0x2, 0xc0000ee280, 0xc0000aa480)
        /Users/dtaniwaki/github/pkg/mod/github.com/spf13/cobra@v0.0.0-20190109003409-7547e83b2d85/command.go:766 +0x2ae
github.com/spf13/cobra.(*Command).ExecuteC(0x13bac60, 0xc00009a000, 0xc0000dbf88, 0xc000070058)
        /Users/dtaniwaki/github/pkg/mod/github.com/spf13/cobra@v0.0.0-20190109003409-7547e83b2d85/command.go:852 +0x2ec
github.com/spf13/cobra.(*Command).Execute(...)
        /Users/dtaniwaki/github/pkg/mod/github.com/spf13/cobra@v0.0.0-20190109003409-7547e83b2d85/command.go:800
main.main()
        /Users/dtaniwaki/github/src/github.com/pfnet-research/git-ghost/main.go:31 +0x2e
```

This PR includes the fix of https://github.com/pfnet-research/git-ghost/pull/37.