### PR TITLE
Remove PWD setup env from e2e tests

### DIFF
--- a/test/util/workdir.go
+++ b/test/util/workdir.go
@@ -115,7 +115,6 @@ func (wd *WorkDir) RunCommmand(command string, args ...string) (string, string, 
 	for key, val := range wd.Env {
 		env = append(env, fmt.Sprintf("%s=%s", key, val))
 	}
-	env = append(env, fmt.Sprintf("PWD=%s", wd.Dir))
 	cmd.Env = env
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr


### PR DESCRIPTION
Thanks to #40, we no longer need to set `PWD` in e2e tests.