### PR TITLE
Add information in how to install

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ $ cd git-ghost
 $ make install
 ```
 
+Compiled binary is located in `dist` folder.
+
+
 ### Using Homebrew
 
 ```bash


### PR DESCRIPTION
I attached a tip that compiled binary will be located in `dist` folder. It could be helpful for those who are not familiar to golang.