### PR TITLE
Drop homebrew installation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,14 +32,6 @@ $ make install
 
 Compiled binary is located in `dist` folder.
 
-
-### Using Homebrew
-
-```bash
-$ brew tap pfnet-research/git-ghost
-$ brew install git-ghost
-```
-
 ### Releases
 
 The binaries of each releases are available in [Releases](../../releases).


### PR DESCRIPTION
https://github.com/pfnet-research/homebrew-git-ghost is now archived. 
homebrew installation won't be supported for the future releases.