### PR TITLE
setup tagpar release flow

### DIFF
--- a/.github/actions/release/actions.yml
+++ b/.github/actions/release/actions.yml
@@ -1,0 +1,41 @@
+name: release
+description: release executables
+
+inputs:
+  tag:
+    description: check out the tag if not empty
+    default: ''
+  token:
+    description: GitHub token
+    required: true
+
+runs:
+  using: composite
+
+  steps:
+  - uses: actions/checkout@v3
+    name: "checkout tag ${{ inputs.tag }}"
+    if: "inputs.tag != ''"
+    with:
+      ref: refs/tags/${{ inputs.tag }}
+    env:
+      GITHUB_TOKEN: ${{ inputs.token }}
+  - name: Set up QEMU for cross-platform image build
+    uses: docker/setup-qemu-action@v2
+  - name: Set up Go
+    uses: actions/setup-go@v2
+    with:
+      go-version: ~1.19
+  - name: Login to GitHub Container Registry
+    uses: docker/login-action@v2
+    with:
+      registry: ghcr.io
+      username: pfnet-research
+      password: ${{ inputs.token }}
+  - name: Run GoReleaser
+    uses: goreleaser/goreleaser-action@v3
+    with:
+      version: v1.11.5
+      args: release --rm-dist
+    env:
+      GITHUB_TOKEN: ${{ inputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,8 @@
-name: Release
+#
+# This workflow runs when tagged manually.
+# It would be useful when tagpr workflow failed in some reason.
+#
+name: Release By Tagged Manually
 
 on:
   push:
@@ -8,23 +12,7 @@ jobs:
   run:
     runs-on: ubuntu-latest
     steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
     - uses: actions/checkout@v3
-    - name: Set up Go
-      uses: actions/setup-go@v2
+    - uses: ./.github/actions/release
       with:
-        go-version: ~1.19
-    - name: Login to GitHub Container Registry
-      uses: docker/login-action@v2
-      with:
-        registry: ghcr.io
-        username: pfnet-research
-        password: ${{ secrets.GITHUB_TOKEN }}
-    - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v3
-      with:
-        version: v1.11.5
-        args: release --rm-dist --debug
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tagpr.yml
+++ b/.github/workflows/tagpr.yml
@@ -1,0 +1,32 @@
+#
+# tagpr master workflow
+#
+name: tagpr
+on:
+  push:
+    branches: ["master"]
+
+jobs:
+  tagpr:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - id: tagpr
+      name: Tagpr
+      uses: Songmu/tagpr@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # If tagpr pushed tags, invoke release custom action manually.
+      # It is because:
+      # > When you use the repository's GITHUB_TOKEN to perform tasks, 
+      # > events triggered by the GITHUB_TOKEN, with the exception of 
+      # > workflow_dispatch and repository_dispatch, will not create 
+      # > a new workflow run.
+      # ref: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+    - name: "Release (only when tagged)"
+      uses: ./.github/actions/release
+      if: "steps.tagpr.outputs.tag != ''"
+      with:
+        tag: ${{ steps.tagpr.outputs.tag }}
+        token: ${{ secrets.GITHUB_TOKEN }}

--- a/.tagpr
+++ b/.tagpr
@@ -1,0 +1,36 @@
+# config file for the tagpr in git config format
+# The tagpr generates the initial configuration, which you can rewrite to suit your environment.
+# CONFIGURATIONS:
+#   tagpr.releaseBranch
+#       Generally, it is "main." It is the branch for releases. The pcpr tracks this branch,
+#       creates or updates a pull request as a release candidate, or tags when they are merged.
+#
+#   tagpr.versionFile
+#       Versioning file containing the semantic version needed to be updated at release.
+#       It will be synchronized with the "git tag".
+#       Often this is a meta-information file such as gemspec, setup.cfg, package.json, etc.
+#       Sometimes the source code file, such as version.go or Bar.pm, is used.
+#       If you do not want to use versioning files but only git tags, specify the "-" string here.
+#       You can specify multiple version files by comma separated strings.
+#
+#   tagpr.vPrefix
+#       Flag whether or not v-prefix is added to semver when git tagging. (e.g. v1.2.3 if true)
+#       This is only a tagging convention, not how it is described in the version file.
+#
+#   tagpr.changelog (Optional)
+#       Flag whether or not changelog is added or changed during the release.
+#
+#   tagpr.command (Optional)
+#       Command to change files just before release.
+#
+#   tagpr.tmplate (Optional)
+#       Pull request template in go template format
+#
+#   tagpr.release (Optional)
+#       GitHub Release creation behavior after tagging [true, draft, false]
+#       If this value is not set, the release is to be created.
+[tagpr]
+	vPrefix = true
+	releaseBranch = master
+	versionFile = -
+	changelog = false

--- a/README.md
+++ b/README.md
@@ -97,10 +97,9 @@ $ godoc -http=:6060  # access http://localhost:6060 in browser
 4. Push to the branch (`git push origin my-new-feature`)
 5. Create new [Pull Request](../../pull/new/master)
 
-## Release Procedure
+## Release
 
-1. Add a semver tag (v[0-9]+.[0-9]+.[0-9]+.) on github
-2. The release workflow will start automatically
+Release flow is fully automated. All the maintainer need to do is just to approve and merge [the next release PR](https://github.com/pfnet-research/git-ghost/pulls?q=is%3Apr+is%3Aopen+label%3Atagpr+)
 
 ## Copyright
 


### PR DESCRIPTION
This PR paves fully automated release flow by https://github.com/Songmu/tagpr.

From the next release, maintainers can release git-ghost by merging the next release PR, which tagpr will set up.


## References

- [リリース用のpull requestを自動作成し、マージされたら自動でタグを打つtagpr](https://songmu.jp/riji/entry/2022-09-05-tagpr.html)
- [tagpr を機能強化してv1.0.0をリリースしました](https://songmu.jp/riji/entry/2022-09-23-tagpr-v1.html)
